### PR TITLE
Version attribute is mandatory since 2021.6

### DIFF
--- a/custom_components/helios/manifest.json
+++ b/custom_components/helios/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "helios",
   "name": "Helios",
+  "version": "1.0.0",
   "documentation": "https://github.com/asev/homeassistant-helios",
   "issue_tracker": "https://github.com/asev/homeassistant-helios/issues",
   "config_flow": true,


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions